### PR TITLE
fix(print): fix logo showing bug

### DIFF
--- a/src/zsh/lib/ui/print.sh
+++ b/src/zsh/lib/ui/print.sh
@@ -61,7 +61,7 @@ cli_campus_logo() {
             while IFS= read -r line; do
                 printf "%s\n" "$line" >&2
             done < $campus_logo_file
-            printf "$(_t "ui.cqupt_logo")\n"
+            printf "$(_t "ui.cqupt_logo")\n" >&2
             cli_divider 0
             ;;
     esac


### PR DESCRIPTION
fix bug like: `~/.local/bin/cntc:15: command not found: ...`